### PR TITLE
LaravelをBuild出来るDockerイメージを作成

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.idea
+.github
+.gitignore
+LICENSE
+README.md
+qiita-stocker-docker.iml

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # qiita-stocker-docker
+
+[Mindexer](https://www.mindexer.net) で共通利用するDockerfileを管理します。
+
+## [nekochans/laravel-build](https://cloud.docker.com/u/nekochans/repository/docker/nekochans/laravel-build)
+
+[![dockeri.co](https://dockeri.co/image/nekochans/laravel-build)](https://hub.docker.com/r/nekochans/laravel-build)

--- a/laravel-build/Dockerfile
+++ b/laravel-build/Dockerfile
@@ -13,4 +13,3 @@ RUN set -x && \
 COPY ./config/php.ini /usr/local/etc/php/php.ini
 
 WORKDIR /app
-

--- a/laravel-build/Dockerfile
+++ b/laravel-build/Dockerfile
@@ -1,0 +1,16 @@
+FROM php:7.3.2-cli-alpine3.9
+
+RUN set -x && \
+  apk update && \
+  apk add --no-cache nodejs nodejs-npm libxml2 libxml2-dev curl curl-dev autoconf $PHPIZE_DEPS && \
+  docker-php-ext-install mysqli pdo pdo_mysql xml mbstring curl session tokenizer json && \
+  curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && \
+  composer global require hirak/prestissimo && \
+  npm install -g npm && \
+  npm install -g yarn && \
+  mkdir -p /app
+
+COPY ./config/php.ini /usr/local/etc/php/php.ini
+
+WORKDIR /app
+

--- a/laravel-build/config/php.ini
+++ b/laravel-build/config/php.ini
@@ -1,0 +1,173 @@
+[PHP]
+engine = On
+short_open_tag = Off
+precision = 14
+output_buffering = 4096
+zlib.output_compression = Off
+implicit_flush = Off
+unserialize_callback_func =
+serialize_precision = -1
+disable_functions =
+disable_classes =
+zend.enable_gc = On
+expose_php = Off
+max_execution_time = 30
+max_input_time = 60
+memory_limit = 128M
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
+display_errors = Off
+display_startup_errors = Off
+log_errors = On
+log_errors_max_len = 1024
+ignore_repeated_errors = Off
+ignore_repeated_source = Off
+report_memleaks = On
+html_errors = On
+error_log = /var/log/php-error.log
+variables_order = "GPCS"
+request_order = "GP"
+register_argc_argv = Off
+auto_globals_jit = On
+post_max_size = 8M
+auto_prepend_file =
+auto_append_file =
+default_mimetype = "text/html"
+default_charset = "UTF-8"
+doc_root =
+user_dir =
+enable_dl = Off
+file_uploads = On
+upload_max_filesize = 2M
+max_file_uploads = 20
+allow_url_fopen = On
+allow_url_include = Off
+default_socket_timeout = 60
+
+[CLI Server]
+cli_server.color = On
+
+[Date]
+date.timezone = Asia/Tokyo
+
+[filter]
+
+[iconv]
+
+[intl]
+
+[sqlite3]
+
+[Pcre]
+pcre.jit=0
+
+[Pdo]
+
+[Pdo_mysql]
+pdo_mysql.cache_size = 2000
+pdo_mysql.default_socket=
+
+[Phar]
+
+[mail function]
+sendmail_path = /usr/sbin/sendmail -t -i
+mail.add_x_header = On
+
+[ODBC]
+odbc.allow_persistent = On
+odbc.check_persistent = On
+odbc.max_persistent = -1
+odbc.max_links = -1
+odbc.defaultlrl = 4096
+odbc.defaultbinmode = 1
+
+[Interbase]
+ibase.allow_persistent = 1
+ibase.max_persistent = -1
+ibase.max_links = -1
+ibase.timestampformat = "%Y-%m-%d %H:%M:%S"
+ibase.dateformat = "%Y-%m-%d"
+ibase.timeformat = "%H:%M:%S"
+
+[MySQLi]
+mysqli.max_persistent = -1
+mysqli.allow_persistent = On
+mysqli.max_links = -1
+mysqli.cache_size = 2000
+mysqli.default_port = 3306
+mysqli.default_socket =
+mysqli.default_host =
+mysqli.default_user =
+mysqli.default_pw =
+mysqli.reconnect = Off
+
+[mysqlnd]
+mysqlnd.collect_statistics = On
+mysqlnd.collect_memory_statistics = Off
+
+[PostgreSQL]
+pgsql.allow_persistent = On
+pgsql.auto_reset_persistent = Off
+pgsql.max_persistent = -1
+pgsql.max_links = -1
+pgsql.ignore_notice = 0
+pgsql.log_notice = 0
+
+[bcmath]
+bcmath.scale = 0
+
+[browscap]
+
+[Session]
+session.save_handler = files
+session.use_strict_mode = 0
+session.use_cookies = 1
+session.use_only_cookies = 1
+session.name = PHPSESSID
+session.auto_start = 0
+session.cookie_lifetime = 0
+session.cookie_path = /
+session.cookie_domain =
+session.cookie_httponly =
+session.serialize_handler = php
+session.gc_probability = 1
+session.gc_divisor = 1000
+session.gc_maxlifetime = 1440
+session.referer_check =
+session.cache_limiter = nocache
+session.cache_expire = 180
+session.use_trans_sid = 0
+session.sid_length = 26
+session.trans_sid_tags = "a=href,area=href,frame=src,form="
+session.sid_bits_per_character = 5
+
+[Assertion]
+zend.assertions = -1
+
+[mbstring]
+mbstring.language = Japanese
+mbstring.encoding_translation = Off
+mbstring.detect_order = UTF-8,SJIS,EUC-JP,JIS,ASCII
+
+[gd]
+
+[exif]
+
+[Tidy]
+tidy.clean_output = Off
+
+[soap]
+soap.wsdl_cache_enabled=1
+soap.wsdl_cache_dir="/tmp"
+soap.wsdl_cache_ttl=86400
+soap.wsdl_cache_limit = 5
+
+[sysvshm]
+
+[ldap]
+ldap.max_links = -1
+
+[dba]
+
+[curl]
+
+[openssl]


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-docker/issues/3

# Doneの定義
- LaravelアプリケーションがBuild出来るDockerイメージがPushされている事

# 変更点概要

## 技術的変更点概要
表題の仕様でDockerイメージを作成

# レビュアーに重点的にチェックして欲しい点
@kobayashi-m42 本当はイメージを分けるべきなんだけど、CodeBuildで複数のDockerイメージを扱うのが面倒そうだったから、PHPとNode.jsを同梱させたイメージを作成したよ🐱！

# 補足情報
https://cloud.docker.com/u/nekochans/repository/docker/nekochans/laravel-build/general