### PR TITLE
オリジナルDockerイメージでデプロイスクリプトが実行出来ない問題を解決

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,34 @@
 ## [nekochans/laravel-build](https://cloud.docker.com/u/nekochans/repository/docker/nekochans/laravel-build)
 
 [![dockeri.co](https://dockeri.co/image/nekochans/laravel-build)](https://hub.docker.com/r/nekochans/laravel-build)
+
+### イメージの更新方法
+
+Dockerfileからイメージを作成します。
+
+```bash
+cd laravel-build/
+docker build -t nekochans/laravel-build .
+```
+
+以下のコマンドで動作確認をします。
+
+```bash
+docker run -it nekochans/laravel-build php -v
+docker run -it nekochans/laravel-build node -v
+docker run -it nekochans/laravel-build npm --version
+docker run -it nekochans/laravel-build yarn --version
+```
+
+各ミドルウェアのバージョンが表示されれば成功です。
+
+GitHub上でタグをPushするとDocker Hub上にも反映されます。
+
+例えばこのようなタグを設定すると・・・
+
+```
+git tag -a v1.0.0 -m "release version v1.0.0"
+git push origin tags/v1.0.0
+```
+
+Docker Hub上では `1.0.0` のタグが自動で作成されます。（`v1.0.0` のように v が必要なので注意）

--- a/laravel-build/Dockerfile
+++ b/laravel-build/Dockerfile
@@ -6,6 +6,7 @@ RUN set -x && \
   yum update && \
   yum install -y git && \
   yum install -y aws-cli && \
+  yum install -y zip unzip && \
   amazon-linux-extras install php7.3 -y && \
   yum install -y php php-opcache php-devel php-opcache php-mbstring php-xml && \
   curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && \

--- a/laravel-build/Dockerfile
+++ b/laravel-build/Dockerfile
@@ -1,15 +1,22 @@
-FROM php:7.3.2-cli-alpine3.9
+FROM amazonlinux:2.0.20190228
+
+ENV TZ=Asia/Tokyo
 
 RUN set -x && \
-  apk update && \
-  apk add --no-cache nodejs nodejs-npm libxml2 libxml2-dev curl curl-dev autoconf $PHPIZE_DEPS && \
-  docker-php-ext-install mysqli pdo pdo_mysql xml mbstring curl session tokenizer json && \
+  yum update && \
+  yum install -y git && \
+  yum install -y aws-cli && \
+  amazon-linux-extras install php7.3 -y && \
+  yum install -y php php-opcache php-devel php-opcache php-mbstring php-xml && \
   curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && \
   composer global require hirak/prestissimo && \
+  yum install -y gcc-c++ make && \
+  curl --silent --location https://rpm.nodesource.com/setup_10.x | bash - && \
+  yum install -y nodejs && \
   npm install -g npm && \
   npm install -g yarn && \
   mkdir -p /app
 
-COPY ./config/php.ini /usr/local/etc/php/php.ini
+COPY ./config/php.ini /etc/php.ini
 
 WORKDIR /app


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-docker/issues/5

# Doneの定義
- https://github.com/nekochans/qiita-stocker-docker/issues/5 の完了の定義を満たしている事

# 変更点概要

## 技術的変更点概要
- ベースイメージを `amazonlinux` の2系に変更しbashとaws-cliを使えるようにした。

# レビュアーに重点的にチェックして欲しい点
@kobayashi-m42 

`Dockerfile` のBuild生成物が1GB近くになっていて（Node.js, PHP, その他てんこ盛り）正直Dockerのアンチパターン（サイズが大きいイメージ）なんだけど、一度CodeBuildがイメージをPullしてしまえば2回目以降はそれなりに早くBuildが終わるから今はこうしているよ🐱！（複数のDockerイメージを1つのCodeBuildプロジェクトで扱う方法も多分あるけど、今はとりあえず完成させる事を優先した）

# 補足情報
以下の2つのPRを解決する為に本件で作成したイメージが必要になる。

- https://github.com/nekochans/qiita-stocker-backend/pull/179
- https://github.com/nekochans/qiita-stocker-terraform/pull/58